### PR TITLE
Simplify _to_petab_scale type signature

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -1,6 +1,6 @@
 function _to_petab_scale(
-        x_inference::T, inference_info::InferenceInfo
-    )::T where {T <: AbstractVector}
+        x_inference::AbstractVector, inference_info::InferenceInfo
+    )::AbstractVector
 
     # Transform x into θ - the scale for the priors
     @unpack inv_bijectors, priors_scale, parameters_scale = inference_info


### PR DESCRIPTION
Fix needed to be able to run Pathfinder from Bayesian_inference_bench. Otherwise this error is thrown:

ERROR: LoadError: MethodError: Cannot `convert` an object of type Vector{Float64} to an object of type SubArray{Float64, 1, Matrix{Float64}, Tuple{Base.Slice{Base.OneTo{Int64}}, Int64}, true}