### PR TITLE
Default prior bug

### DIFF
--- a/src/structs.jl
+++ b/src/structs.jl
@@ -50,9 +50,9 @@ function InferenceInfo(petab_problem::PEtabODEProblem)::InferenceInfo
         # on parameter scale with lb and ub as bounds
         if !in(ix, priors.ix_prior)
             if isinf(lower_bounds[ix]) || isinf(upper_bounds[ix])
-                @warn "Lower or upper bounds for parameter $(parameter_names[ix]) is \
-                    -inf and/or inf. Assigning default Uniform prior with linear-scale \
-                    fallback bounds 1e-3 and 1e3"
+                @warn "Lower or upper bound for parameter $(parameter_names[ix]) is \
+                    -inf and/or inf on the parameter scale. Assigning default Uniform \
+                    prior with linear-scale fallback bounds 1e-3 and 1e3"
                 priors_dist[ix] = Uniform(_default_uniform_prior_bounds(parameters_scale[ix])...)
             else
                 priors_dist[ix] = Uniform(lower_bounds[ix], upper_bounds[ix])

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -43,7 +43,7 @@ function InferenceInfo(petab_problem::PEtabODEProblem)::InferenceInfo
             else
                 priors_dist[ix] = Uniform(lower_bounds[ix], upper_bounds[ix])
             end
-            priors_scale[ix] = :lin
+            priors_scale[ix] = parameters_scale[ix] === :lin ? :lin : :parameter_scale
         else
             jx = findfirst(x -> x == ix, priors.ix_prior)
             priors_dist[ix] = priors.distributions[jx]

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -12,6 +12,19 @@ struct InferenceInfo{
     parameters_scale::Vector{Symbol}
     parameters_id::Vector{Symbol}
 end
+function _default_uniform_prior_bounds(scale::Symbol)::Tuple{Float64, Float64}
+    lower_bound = 1.0e-3
+    upper_bound = 1.0e3
+    if scale === :log10
+        return log10(lower_bound), log10(upper_bound)
+    elseif scale === :log
+        return log(lower_bound), log(upper_bound)
+    elseif scale === :log2
+        return log2(lower_bound), log2(upper_bound)
+    end
+    return lower_bound, upper_bound
+end
+
 function InferenceInfo(petab_problem::PEtabODEProblem)::InferenceInfo
     @unpack model_info, lower_bounds, upper_bounds, xnominal = petab_problem
     @unpack priors, petab_parameters = model_info
@@ -36,10 +49,11 @@ function InferenceInfo(petab_problem::PEtabODEProblem)::InferenceInfo
         # In case the parameter lacks a defined prior we default to a Uniform
         # on parameter scale with lb and ub as bounds
         if !in(ix, priors.ix_prior)
-            if abs(isinf(lower_bounds[ix])) || isinf(upper_bounds[ix])
+            if isinf(lower_bounds[ix]) || isinf(upper_bounds[ix])
                 @warn "Lower or upper bounds for parameter $(parameter_names[ix]) is \
-                    -inf and/or inf. Assigning Uniform(1e-3, 1e3) prior"
-                priors_dist[ix] = Uniform(1.0e-3, 1.0e3)
+                    -inf and/or inf. Assigning default Uniform prior with linear-scale \
+                    fallback bounds 1e-3 and 1e3"
+                priors_dist[ix] = Uniform(_default_uniform_prior_bounds(parameters_scale[ix])...)
             else
                 priors_dist[ix] = Uniform(lower_bounds[ix], upper_bounds[ix])
             end

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -24,10 +24,42 @@ function _default_uniform_prior_bounds(scale::Symbol)::Tuple{Float64, Float64}
     end
     return lower_bound, upper_bound
 end
+function _default_uniform_prior(
+        parameter_name::Symbol,
+        parameter_scale::Symbol,
+        lower_bound_parameter_scale::Float64,
+        upper_bound_parameter_scale::Float64,
+        lower_bound_linear_scale::Float64,
+        upper_bound_linear_scale::Float64,
+        petab_version::String,
+    )
+    if petab_version == "2.0.0"
+        prior_scale = :lin
+        lower_bound = lower_bound_linear_scale
+        upper_bound = upper_bound_linear_scale
+        bounds_scale = "linear"
+    else
+        prior_scale = parameter_scale === :lin ? :lin : :parameter_scale
+        lower_bound = lower_bound_parameter_scale
+        upper_bound = upper_bound_parameter_scale
+        bounds_scale = prior_scale === :parameter_scale ? "parameter" : "linear"
+    end
+
+    if isinf(lower_bound) || isinf(upper_bound)
+        @warn "Lower or upper bound for parameter $(parameter_name) is -inf and/or inf \
+            on the $(bounds_scale) scale. Assigning default Uniform prior with \
+            linear-scale fallback bounds 1e-3 and 1e3"
+        fallback_scale = prior_scale === :parameter_scale ? parameter_scale : :lin
+        lower_bound, upper_bound = _default_uniform_prior_bounds(fallback_scale)
+    end
+
+    return Uniform(lower_bound, upper_bound), prior_scale
+end
 
 function InferenceInfo(petab_problem::PEtabODEProblem)::InferenceInfo
     @unpack model_info, lower_bounds, upper_bounds, xnominal = petab_problem
     @unpack priors, petab_parameters = model_info
+    petab_version = PEtab._get_version(model_info)
 
     parameter_names = Symbol.(labels(xnominal))
     n_parameters = length(parameter_names)
@@ -38,6 +70,8 @@ function InferenceInfo(petab_problem::PEtabODEProblem)::InferenceInfo
     parameters_scale = similar(parameter_names)
 
     for (ix, θ) in pairs(parameter_names)
+        iθ = nothing
+
         # ML parameters are always on linear scale
         if ix in model_info.xindices.indices_est[:est_to_mech]
             iθ = findfirst(x -> x == θ, petab_parameters.parameter_id)
@@ -49,15 +83,19 @@ function InferenceInfo(petab_problem::PEtabODEProblem)::InferenceInfo
         # In case the parameter lacks a defined prior we default to a Uniform
         # on parameter scale with lb and ub as bounds
         if !in(ix, priors.ix_prior)
-            if isinf(lower_bounds[ix]) || isinf(upper_bounds[ix])
-                @warn "Lower or upper bound for parameter $(parameter_names[ix]) is \
-                    -inf and/or inf on the parameter scale. Assigning default Uniform \
-                    prior with linear-scale fallback bounds 1e-3 and 1e3"
-                priors_dist[ix] = Uniform(_default_uniform_prior_bounds(parameters_scale[ix])...)
-            else
-                priors_dist[ix] = Uniform(lower_bounds[ix], upper_bounds[ix])
-            end
-            priors_scale[ix] = parameters_scale[ix] === :lin ? :lin : :parameter_scale
+            lower_bound_linear_scale = isnothing(iθ) ? lower_bounds[ix] :
+                petab_parameters.lower_bounds[iθ]
+            upper_bound_linear_scale = isnothing(iθ) ? upper_bounds[ix] :
+                petab_parameters.upper_bounds[iθ]
+            priors_dist[ix], priors_scale[ix] = _default_uniform_prior(
+                parameter_names[ix],
+                parameters_scale[ix],
+                lower_bounds[ix],
+                upper_bounds[ix],
+                lower_bound_linear_scale,
+                upper_bound_linear_scale,
+                petab_version,
+            )
         else
             jx = findfirst(x -> x == ix, priors.ix_prior)
             priors_dist[ix] = priors.distributions[jx]

--- a/test/bijectors.jl
+++ b/test/bijectors.jl
@@ -138,3 +138,21 @@ log_density = PEtabBayesLogDensity(prob_test)
 @test log_density.inference_info.priors_scale == [:lin, :parameter_scale]
 @test params(log_density.inference_info.priors[2]) == (-3.0, 3.0)
 @test PEtabBayes.to_prior_scale(get_x(prob_test), log_density)[2] == get_x(prob_test)[2]
+
+prior, prior_scale = PEtabBayes._default_uniform_prior(
+    :k1, :log10, -2.0, 1.0, 0.01, 10.0, "1.0.0"
+)
+@test prior_scale == :parameter_scale
+@test params(prior) == (-2.0, 1.0)
+
+prior, prior_scale = PEtabBayes._default_uniform_prior(
+    :k1, :log10, -Inf, 1.0, 0.0, 10.0, "1.0.0"
+)
+@test prior_scale == :parameter_scale
+@test params(prior) == (-3.0, 3.0)
+
+prior, prior_scale = PEtabBayes._default_uniform_prior(
+    :k1, :log10, -Inf, 1.0, 0.0, 10.0, "2.0.0"
+)
+@test prior_scale == :lin
+@test params(prior) == (0.0, 10.0)

--- a/test/bijectors.jl
+++ b/test/bijectors.jl
@@ -127,3 +127,14 @@ log_density = PEtabBayesLogDensity(prob_test)
     prob_test.lower_bounds[2], prob_test.upper_bounds[2],
 )
 @test PEtabBayes.to_prior_scale(get_x(prob_test), log_density)[2] == get_x(prob_test)[2]
+
+# Default fallback priors are transformed to parameter scale
+p_est = [
+    PEtabParameter(:k1; scale = :lin, prior = Uniform(0.0, 2.0), value = 1.1),
+    PEtabParameter(:k2; scale = :log10, lb = 0.0, ub = 10.0, value = 0.9),
+]
+prob_test = _get_petab_problem(p_est)
+log_density = PEtabBayesLogDensity(prob_test)
+@test log_density.inference_info.priors_scale == [:lin, :parameter_scale]
+@test params(log_density.inference_info.priors[2]) == (-3.0, 3.0)
+@test PEtabBayes.to_prior_scale(get_x(prob_test), log_density)[2] == get_x(prob_test)[2]

--- a/test/bijectors.jl
+++ b/test/bijectors.jl
@@ -114,3 +114,16 @@ p_est = [
     PEtabParameter(:k2; scale = :log10, prior = LogNormal(0.0, 1.0), value = 0.9),
 ]
 test_bijectors(p_est)
+
+# Default priors on nonlinear parameter scale
+p_est = [
+    PEtabParameter(:k1; scale = :lin, prior = Uniform(0.0, 2.0), value = 1.1),
+    PEtabParameter(:k2; scale = :log10, lb = 0.01, ub = 10.0, value = 0.9),
+]
+prob_test = _get_petab_problem(p_est)
+log_density = PEtabBayesLogDensity(prob_test)
+@test log_density.inference_info.priors_scale == [:lin, :parameter_scale]
+@test params(log_density.inference_info.priors[2]) == (
+    prob_test.lower_bounds[2], prob_test.upper_bounds[2],
+)
+@test PEtabBayes.to_prior_scale(get_x(prob_test), log_density)[2] == get_x(prob_test)[2]


### PR DESCRIPTION
There was a bug when the parameter scale was set to something other than linear and no explicit prior was set for a parameter. The fallback prior was then set to uniform with the lower and upper bounds transformed to the parameter scale. For example, Uniform(log10(lb), log10(ub)) if scale=:log10. The priors_scale was then still set to :lin, even though this was incorrect.

Now the same case is handled by setting the Uniform distribution to be on the parameter scale.

Additionally, the fallback prior when the transformed lower bound or upper upper bound ends up being -Inf or Inf, is transformed to the correct parameter scale.